### PR TITLE
Fix import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ TBD:
 ### Basic usage :
 ```python
 from opmd_viewer import OpenPMDTimeSeries
-from opmd2VTK.opmd2VTK import opmd2VTK
+from opmd2VTK import Opmd2VTK
 
 ts = OpenPMDTimeSeries('./diags/hdf5/')
-conv = opmd2VTK(ts)
+conv = Opmd2VTK(ts)
 
 conv.write_fields_vtk(iteration=ts.iterations[-1])
 ```

--- a/opmd2VTK/__init__.py
+++ b/opmd2VTK/__init__.py
@@ -1,0 +1,1 @@
+from .opmd2VTK import Opmd2VTK

--- a/opmd2VTK/opmd2VTK.py
+++ b/opmd2VTK/opmd2VTK.py
@@ -23,7 +23,7 @@ import pyvtk as vtk
 import numpy as np
 import os
 
-class opmd2VTK:
+class Opmd2VTK:
     """
     Main class for the opmd2VTK converter
     Class is initialzed with the OpenPMDTimeSeries object from openPMD-viewer.


### PR DESCRIPTION
From offline discussions with @hightower8083 : it would be good to shorten the required `import` statement for `opmd2VTK`. This is in done, in this PR, by importing the main class in the `__init__.py`. 

Note that I also slightly modified the name of the class so as to comply with PEP8 (i.e. class name usually start with a capital letter.)